### PR TITLE
fix: GetReleasePR : check if head branch and base branch are correct

### DIFF
--- a/internal/pkg/gh/gh.go
+++ b/internal/pkg/gh/gh.go
@@ -290,7 +290,7 @@ func (g *gh) GetReleasePR(ctx context.Context, fromBranch, toBranch string) (*gi
 		return nil, err
 	}
 	for _, pr := range prs {
-		if pr.MergedAt == nil {
+		if pr.GetBase().GetRef() == toBranch && pr.GetHead().GetRef() == fromBranch && pr.MergedAt == nil {
 			existsPR = pr
 			break
 		}


### PR DESCRIPTION
If `develop -> main` , it works fine, but after merge to main
If I create a PR for `main -> develop` after merge to main, I get the wrong PR for `develop`.

Added a process to check if the head branch and base branch are the expected branches.