### PR TITLE
Fix GoReleaser v2 release configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,5 +35,12 @@ jobs:
           go install gotest.tools/gotestsum@latest
           go mod download
 
+      - name: Validate GoReleaser config
+        uses: goreleaser/goreleaser-action@3fa32b8bb5620a2c1afe798654bbad59f9da4906 # v4.4.0
+        with:
+          distribution: goreleaser
+          version: latest
+          args: check --config .goreleaser.yaml
+
       - name: Test code
         run: gotestsum --junitfile unit-tests.xml -- -v -race ./...

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 env:
   - GO111MODULE=on
   - CGO_ENABLED=0
@@ -29,8 +31,7 @@ builds:
       - -X main.date={{.Date}}
 
 archives:
-  - rlcp: true
-    name_template: >-
+  - name_template: >-
       {{ .ProjectName }}_
       {{- .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
@@ -38,7 +39,8 @@ archives:
       {{- else }}{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ end }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
     files:
       - README.md
       - LICENSE


### PR DESCRIPTION
## Summary
- add `version: 2` to `.goreleaser.yaml` and remove the removed `archives.rlcp` setting
- switch the Windows archive override to the current `formats` syntax so `goreleaser check` passes on the latest v2 release
- validate `.goreleaser.yaml` in the test workflow so PRs catch release-config drift before a tag is pushed

## Root cause
The release workflow at https://github.com/tomtwinkle/go-pr-release/actions/runs/25470871468/job/74734279084 failed because the repository was running the latest GoReleaser v2, while `.goreleaser.yaml` was still using the pre-v2 config shape and a removed archive option.

## Validation
- `go run github.com/goreleaser/goreleaser/v2@v2.15.4 check --config .goreleaser.yaml`
- `go test ./...`